### PR TITLE
Reorganize Pattern-Matching section information

### DIFF
--- a/docs/extending/code-overview/pattern-matching.rst
+++ b/docs/extending/code-overview/pattern-matching.rst
@@ -1,41 +1,57 @@
 
-.. index:: patternmatching
+.. index:: Pattern Matching; Evaluation
 .. _patternmatching:
 
 .. contents::
 
-=================
-Pattern matching
-=================
+==============================
+Pattern Matching in Evaluation
+==============================
 
+Pattern matching is used in evalutation of Mathics Expression and therefore in Function resolution. Because this process is both time consuming and involved, it is important to understand how it works. We describe some of this process here.
 
+Based on the ``Head`` of a Mathics Expression, the rules stored the ``Definitions`` object for ``Head`` are examined for matches.
+When a rule matches an expression, the rule specifies how sub-expressions get bound to names, and how the expression is transformed. After this happens, the evaluation process is repeated using the replaced expression.
 
-One of the most involved aspects of the core implementation is the pattern matching mechanism. The evaluation mechanism in the core 
-consists on taking an (S-)expression,  looking for replace rules stored in the `Definitions` object that match the full expression or some of 
-its sub-expressions, and apply them until the expression converges to its final form. The power of the WL then relies in the possibility of defining 
-rules by patterns that can match with many different expressions, and building new expressions based on the variable part of the pattern.
-For this reason, when performance is important, to understand the pattern matching mechanism becomes essential.
+The process repeats until the expression converges and there are no further changes.
 
-Lets start from the begining. `Pattern` (defined in `mathics.core.pattern`) is the base class that represents the pattern for an expression. 
-We have two basic subclasses: `AtomPattern`s that represent  patterns that match with a given atomic expression,  and `ExpressionPattern`s that represent patterns
-that matches with non-atomic expressions (i.e., expressions with a head and leaves). We also have several `Builtin` symbols (defined in `mathics.builtin.patterns`)
-representing different pattern constructions (like `Pattern_`, `Blank`, `PatternTest` or `Alternatives`). All of these `Builtin`s are derivated from 
-the `PatternObject' class, which is at its time is derivated from `InstanceableBuiltin` and `Pattern`.
+The power of the WL then relies in the possibility of defining rules by patterns that can match with many different expressions, and building new expressions based on the variable part of the pattern.
 
-Every `Pattern` object has three important methods: `does_match`, `get_match_candidates`, and `match`.  The first one checks if certain expression matches the pattern. 
-`get_match_candidates` takes a list of leaves and finds all the elements that matches. Finally, `match` is the most involved method and has the following profile:
+Pattern Classes
+---------------
 
-`match(yield_func,
-       expression,
-       vars,
-       evaluation,
-       head=None,
-       leaf_index=None,
-       leaf_count=None,
-       fully=True,
-       wrap_oneid=True,
-)`
+We now describe the Class heirarchy for ``Pattern`` which is defined in ``mathics.core.pattern``.  This is the base class that represents the pattern for an expression.
 
-When called, this method explores `expression` and its leaves, looking for subexpressions that match the pattern. Each time a coincidence is found,
-`yield_func(vars, rest)` is called with `vars` as a first parameter, and the second parameter depends on the specific context.
+Two of its subclasses are:
 
+* ``AtomPattern`` patterns that match with a given atomic expression,  and
+* ``ExpressionPattern`` patterns matches with non-atomic expressions (i.e., expressions with a head and leaves).
+
+There are also have several ``Builtin`` symbols (defined in ``mathics.builtin.patterns``) that
+represent different pattern constructions like ``Pattern_``, ``Blank``, ``PatternTest`` or ``Alternatives``. All of these ``Builtin`` classes are derived from
+the ``PatternObject`` class, which is derived from ``InstanceableBuiltin`` and ``Pattern``.
+
+Every ``Pattern`` object has three important methods: ``does_match()``, ``get_match_candidates()``, and ``match()``:
+
+* ``does_match()`` checks if certain expression matches the pattern
+* ``get_match_candidates()`` finds all the potential matches
+* ``match()`` performs what needs to be done when there is a match
+
+The last method, ``match()``, is the most involved. It has the following function signature:
+
+.. code-block:: python
+
+    match(yield_func, expression,
+          vars,
+          evaluation,
+          head=None,
+          leaf_index=None,
+          leaf_count=None,
+          fully=True,
+          wrap_oneid=True
+	  )
+
+When called, this method binds subexpressions of the expression to
+parts of the pattern. For each match, ``yield_func(vars, rest)`` is
+called with ``vars`` as a first parameter, and the second parameter
+depends on the specific context.

--- a/docs/extending/code-overview/pattern-matching.rst
+++ b/docs/extending/code-overview/pattern-matching.rst
@@ -8,7 +8,7 @@
 Pattern Matching in Evaluation
 ==============================
 
-Pattern matching is used in evalutation of Mathics Expression and therefore in Function resolution. Because this process is both time consuming and involved, it is important to understand how it works. We describe some of this process here.
+Pattern matching is used in evaluation of Mathics Expression and therefore in Function resolution. Because this process is both time consuming and involved, it is important to understand how it works. We describe some of this process here.
 
 Based on the ``Head`` of a Mathics Expression, the rules stored the ``Definitions`` object for ``Head`` are examined for matches.
 When a rule matches an expression, the rule specifies how sub-expressions get bound to names, and how the expression is transformed. After this happens, the evaluation process is repeated using the replaced expression.
@@ -20,7 +20,7 @@ The power of the WL then relies in the possibility of defining rules by patterns
 Pattern Classes
 ---------------
 
-We now describe the Class heirarchy for ``Pattern`` which is defined in ``mathics.core.pattern``.  This is the base class that represents the pattern for an expression.
+We now describe the Class hierarchy for ``Pattern`` which is defined in ``mathics.core.pattern``.  This is the base class that represents the pattern for an expression.
 
 Two of its subclasses are:
 


### PR DESCRIPTION
Also some small grammar and sphinx tagging things.

I may have gotten things wrong, so please review.

Some general sphinx things: 

* use double backtick for preformatted code (single backtick is for references; yes, markdown does things differently.).
* Index entries are words that appear in the Index, so they should be words not identifiers.